### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Imports:
     reshape2,
     rstantools (>= 2.1.1),
     rlang,
-    rstan (>= 2.18.1),
+    rstan (>= 2.26.0),
     splines,
     viridisLite
 LinkingTo: 
@@ -44,8 +44,8 @@ LinkingTo:
     Rcpp (>= 0.12.0),
     RcppEigen (>= 0.3.3.3.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
-    StanHeaders (>= 2.18.1)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 Suggests:
     testthat,
     parallel,

--- a/R/fit_dfa.R
+++ b/R/fit_dfa.R
@@ -542,7 +542,7 @@ fit_dfa <- function(y = y,
     est_nb2_params = est_nb2_params,
     gp_theta_prior = gp_theta_prior,
     use_expansion_prior = as.integer(expansion_prior),
-    offset = offset_vec,
+    input_offset = offset_vec,
     weights_vec = weights_vec
   )
 

--- a/inst/stan/dfa.stan
+++ b/inst/stan/dfa.stan
@@ -69,22 +69,22 @@ data {
   int<lower=0> P; // number of time series of data
   int<lower=0> K; // number of trends
   int<lower=0> nZ; // number of unique z elements
-  int<lower=0> row_indx[nZ];
-  int<lower=0> col_indx[nZ];
+  array[nZ] int<lower=0> row_indx;
+  array[nZ] int<lower=0> col_indx;
   int<lower=0> nVariances;
-  int<lower=0> varIndx[P];
+  array[P] int<lower=0> varIndx;
   int<lower=0> nZero;
-  int<lower=0> row_indx_z[nZero];
-  int<lower=0> col_indx_z[nZero];
+  array[nZero] int<lower=0> row_indx_z;
+  array[nZero] int<lower=0> col_indx_z;
   int<lower=0> n_pos; // number of non-missing observations
-  int<lower=0> row_indx_pos[n_pos]; // row indices of non-missing obs
-  int<lower=0> col_indx_pos[n_pos]; // col indices of non-missing obs
-  real y[n_pos]; // vectorized matrix of observations
-  int<lower=0> y_int[n_pos]; // vectorized matrix of observations
-  real offset[n_pos]; // vector of offset (no estimated coefficient)
+  array[n_pos] int<lower=0> row_indx_pos; // row indices of non-missing obs
+  array[n_pos] int<lower=0> col_indx_pos; // col indices of non-missing obs
+  array[n_pos] real y; // vectorized matrix of observations
+  array[n_pos] int<lower=0> y_int; // vectorized matrix of observations
+  array[n_pos] real offset; // vector of offset (no estimated coefficient)
   int<lower=0> n_na; // number of missing observations
-  int<lower=0> row_indx_na[n_na]; // row indices of missing obs
-  int<lower=0> col_indx_na[n_na]; // col indices of missing obs
+  array[n_na] int<lower=0> row_indx_na; // row indices of missing obs
+  array[n_na] int<lower=0> col_indx_na; // col indices of missing obs
   real<lower=1> nu_fixed; // df on student-t
   int estimate_nu; // Estimate degrees of freedom?
   int use_normal; // flag, for large values of nu > 100, use normal instead
@@ -93,14 +93,14 @@ data {
   int est_theta; // whether to estimate moving-average in trends (=1) or not (= 0
   int<lower=0> num_obs_covar; // number of unique observation covariates, dimension of matrix
   int<lower=0> n_obs_covar; // number of unique covariates included
-  int obs_covar_index[num_obs_covar,3];// indexed by time, trend, covariate #, covariate value. +1 because of indexing issues
-  real obs_covar_value[num_obs_covar];
-  int match_obs_covar[num_obs_covar];
+  array[num_obs_covar,3] int obs_covar_index;// indexed by time, trend, covariate #, covariate value. +1 because of indexing issues
+  array[num_obs_covar] real obs_covar_value;
+  array[num_obs_covar] int match_obs_covar;
   int<lower=0> num_pro_covar; // number of unique process covariates, dimension of matrix
   int<lower=0> n_pro_covar; // number of unique process covariates included
-  int pro_covar_index[num_pro_covar,3];// indexed by time, trend, covariate #, covariate value. +1 because of indexing issues
-  real pro_covar_value[num_pro_covar];
-  real z_bound[2];
+  array[num_pro_covar,3] int pro_covar_index;// indexed by time, trend, covariate #, covariate value. +1 because of indexing issues
+  array[num_pro_covar] real pro_covar_value;
+  array[2] real z_bound;
   int<lower=0> long_format; // data shape, 0 == wide (default), 1 = long with potential for multiple observations
   int<lower=0> proportional_model;
   int<lower=0> est_sigma_process; // optional, 0 == not estimate sigma_pro (default), 1 == estimate
@@ -110,7 +110,7 @@ data {
   int<lower=0> est_gp; // single value, 0 if false 1 if true to model trends with predictive gaussian process
   int<lower=0> n_knots; // single value representing knots for b-spline or gp process
   matrix[N, n_knots] X_spline;
-  real knot_locs[n_knots]; // inputs of knot locations for GP model
+  array[n_knots] real knot_locs; // inputs of knot locations for GP model
   //real data_locs[N]; // locations of data
   //matrix[n_knots, n_knots] distKnots;
   //matrix[N, n_knots] distKnots21;
@@ -120,15 +120,15 @@ data {
   int<lower=0, upper=1> est_gamma_params;
   int<lower=0, upper=1> est_nb2_params;
   int<lower=0, upper=1> use_expansion_prior;
-  real gp_theta_prior[2];
-  real weights_vec[n_pos];
+  array[2] real gp_theta_prior;
+  array[n_pos] real weights_vec;
 }
 transformed data {
   int n_pcor; // dimension for cov matrix
   int n_loglik; // dimension for loglik calculation
   vector[K] zeros;
-  real data_locs[N]; // for gp model
-  real log_weights_vec[n_pos]; // weights
+  array[N] real data_locs; // for gp model
+  array[n_pos] real log_weights_vec; // weights
   vector[K*proportional_model] alpha_vec;
   vector[n_knots] muZeros;
   real gp_delta = 1e-9; // stabilizing value for GP model
@@ -185,21 +185,21 @@ parameters {
   vector<lower=0>[K*(1-proportional_model)*use_expansion_prior] psi; // expansion parameters
   vector<lower=z_bound[1],upper=z_bound[2]>[nZ*(1-proportional_model)] z; // estimated loadings in vec form
   vector<lower=lower_bound_z>[K*(1-proportional_model)] zpos; // constrained positive values
-  simplex[K] p_z[P*proportional_model]; // alternative for proportional Z
+  array[P*proportional_model] simplex[K] p_z; // alternative for proportional Z
   matrix[K * est_spline, n_knots * est_spline] spline_a; // weights for b-splines
   matrix[n_obs_covar, P] b_obs; // coefficients on observation model
   matrix[n_pro_covar, K] b_pro; // coefficients on process model
-  real<lower=0> sigma[nVariances*est_sigma_params];
-  real<lower=0> gamma_a[nVariances*est_gamma_params];
-  real<lower=0> nb2_phi[nVariances*est_nb2_params];
-  real<lower=2> nu[estimate_nu]; // df on student-t
+  array[nVariances*est_sigma_params] real<lower=0> sigma;
+  array[nVariances*est_gamma_params] real<lower=0> gamma_a;
+  array[nVariances*est_nb2_params] real<lower=0> nb2_phi;
+  array[estimate_nu] real<lower=2> nu; // df on student-t
   real ymiss[n_na];
-  real<lower=-1,upper=1> phi[est_phi*K]; // AR(1) coefficients specific to each trend
-  real<lower=-1,upper=1> theta[est_theta*K];// MA(1) coefficients specific to each trend
-  real<lower=0> gp_theta[est_gp*K];// gp_theta coefficients specific to each trend
+  array[est_phi*K] real<lower=-1,upper=1> phi; // AR(1) coefficients specific to each trend
+  array[est_theta*K] real<lower=-1,upper=1> theta;// MA(1) coefficients specific to each trend
+  array[est_gp*K] real<lower=0> gp_theta;// gp_theta coefficients specific to each trend
   cholesky_factor_corr[n_pcor] Lcorr; // matrix for correlated errros
-  real<lower=0> sigma_process[est_sigma_process * n_sigma_process]; // process variances, potentially unique
-  vector[n_knots* est_gp] effectsKnots[K * est_gp]; // gaussian predictive process
+  array[est_sigma_process * n_sigma_process] real<lower=0> sigma_process; // process variances, potentially unique
+  array[K * est_gp] vector[n_knots* est_gp] effectsKnots; // gaussian predictive process
 }
 transformed parameters {
   matrix[P,N] pred; //vector[P] pred[N];
@@ -223,7 +223,7 @@ transformed parameters {
   real sigma11;// temporary for calculations for MVN model
   vector[K] sigma_pro;
   matrix[K * est_spline, n_knots * est_spline] spline_a_trans; // weights for b-splines
-  matrix[n_knots, n_knots] SigmaKnots[K]; // matrix for GP model, unique for each trend K
+  array[K] matrix[n_knots, n_knots] SigmaKnots; // matrix for GP model, unique for each trend K
   //matrix[N, n_knots] SigmaOffDiag;// matrix for GP model
   //matrix[N, n_knots] SigmaOffDiagTemp;// matrix for GP model
   vector[n_pos] obs_cov_offset;

--- a/inst/stan/hmm_gaussian.stan
+++ b/inst/stan/hmm_gaussian.stan
@@ -10,9 +10,9 @@ functions {
 data {
   int<lower=1> T;                   // number of observations (length)
   int<lower=1> K;                   // number of hidden states
-  real x_t[T];                      // observations
+  array[T] real x_t;                      // observations
   int<lower=0> est_sigma;           // flag, whether to estimate sigma (1) or use values passed in (0)
-  real sigma_t[T];               // estimated sigma for each observation
+  array[T] real sigma_t;               // estimated sigma for each observation
 }
 
 parameters {
@@ -22,14 +22,14 @@ parameters {
                                     // A_ij[i][j] = p(z_t = j | z_{t-1} = i)
   // Continuous observation model
   ordered[K] mu_k;                  // observation means
-  real<lower=0> sigma_k[K];         // observation standard deviations, optionally estimated if est_sigma == 1. Can the quantity K * est_sigma be used to dimension sigma_k?
+  array[K] real<lower=0> sigma_k;         // observation standard deviations, optionally estimated if est_sigma == 1. Can the quantity K * est_sigma be used to dimension sigma_k?
 }
 
 transformed parameters {
-  vector[K] unalpha_tk[T];
+  array[T] vector[K] unalpha_tk;
 
   { // Forward algorithm log p(z_t = j | x_{1:t})
-    real accumulator[K];
+    array[K] real accumulator;
 
     if(est_sigma == 1) {
       // use estimated sigma values
@@ -66,13 +66,13 @@ model {
 }
 
 generated quantities {
-  vector[K] unbeta_tk[T];
-  vector[K] ungamma_tk[T];
-  vector[K] alpha_tk[T];
-  vector[K] beta_tk[T];
-  vector[K] gamma_tk[T];
+  array[T] vector[K] unbeta_tk;
+  array[T] vector[K] ungamma_tk;
+  array[T] vector[K] alpha_tk;
+  array[T] vector[K] beta_tk;
+  array[T] vector[K] gamma_tk;
   vector[T] log_lik; // added to store log-likelihood for calculation of LOOIC
-  int<lower=1, upper=K> zstar_t[T];
+  array[T] int<lower=1, upper=K> zstar_t;
   real logp_zstar_t;
 
   { // Forward algortihm
@@ -136,8 +136,8 @@ generated quantities {
   } // Forwards-backwards
 
   { // Viterbi algorithm
-    int a_tk[T, K];                 // backpointer to the most likely previous state on the most probable path
-    real delta_tk[T, K];            // max prob for the seq up to t
+    array[T, K] int a_tk;                 // backpointer to the most likely previous state on the most probable path
+    array[T, K] real delta_tk;            // max prob for the seq up to t
                                     // with final output from state k for time t
     if(est_sigma == 1) {
     for (j in 1:K)

--- a/inst/stan/hmm_gaussian.stan
+++ b/inst/stan/hmm_gaussian.stan
@@ -18,7 +18,7 @@ data {
 parameters {
   // Discrete state model
   simplex[K] p_1k;                  // initial state probabilities
-  simplex[K] A_ij[K];               // transition probabilities
+  array[K] simplex[K] A_ij;               // transition probabilities
                                     // A_ij[i][j] = p(z_t = j | z_{t-1} = i)
   // Continuous observation model
   ordered[K] mu_k;                  // observation means
@@ -81,7 +81,7 @@ generated quantities {
   } // Forward
 
   { // Backward algorithm log p(x_{t+1:T} | z_t = j)
-    real accumulator[K];
+    array[K] real accumulator;
 
     for (j in 1:K)
       unbeta_tk[T, j] = 1;

--- a/inst/stan/regime_1.stan
+++ b/inst/stan/regime_1.stan
@@ -1,16 +1,16 @@
 data {
   int<lower=1> T;                   // number of observations (length)
   int<lower=1> K;                   // number of hidden states
-  real x_t[T];                      // observations
+  array[T] real x_t;                      // observations
   int<lower=0> est_sigma;           // flag, whether to estimate sigma (1) or use values passed in (0)
-  real sigma_t[T];               // estimated sigma for each observation
+  array[T] real sigma_t;               // estimated sigma for each observation
 }
 parameters {
   real mu_k;                  // observation means
   real<lower=0> sigma_k;         // observation standard deviations, optionally estimated if est_sigma == 1. Can the quantity K * est_sigma be used to dimension sigma_k?
 }
 transformed parameters {
-  real sigmas[T];
+  array[T] real sigmas;
   if(est_sigma == 1) {
     for(i in 1:T) sigmas[i] = sigma_k;
   } else {


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax
- `offset` is a reserved keyword, changed to `input_offset`
- `cov_exp_quad` replaced by `gp_exp_quad_cov`

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
