### PR TITLE
Compatibility with upcoming loo package release

### DIFF
--- a/R/find_regimes.R
+++ b/R/find_regimes.R
@@ -33,8 +33,14 @@ find_regimes <- function(y,
       chains = chains, ...
     )
     looic <- loo.bayesdfa(fit)
-    loo_bad <- loo::pareto_k_table(looic)["(0.7, 1]", "Count"]
-    loo_very_bad <- loo::pareto_k_table(looic)["(1, Inf)", "Count"]
+    k_table <- loo::pareto_k_table(looic)
+    if (utils::packageVersion("loo") <= "2.6.0") {
+      loo_bad <- k_table["(0.7, 1]", "Count"]
+      loo_very_bad <- k_table["(1, Inf)", "Count"]
+    } else {
+      loo_bad <- k_table[2, "Count"]
+      loo_very_bad <- k_table[3, "Count"]
+    }
     df$looic[which(df$regimes == regime)] <- looic$estimates["looic", "Estimate"]
 
     if (fit$looic < best_loo) {

--- a/R/find_regimes.R
+++ b/R/find_regimes.R
@@ -34,7 +34,7 @@ find_regimes <- function(y,
     )
     looic <- loo.bayesdfa(fit)
     k_table <- loo::pareto_k_table(looic)
-    if (utils::packageVersion("loo") <= "2.6.0") {
+    if (nrow(k_table) == 4) {
       loo_bad <- k_table["(0.7, 1]", "Count"]
       loo_very_bad <- k_table["(1, Inf)", "Count"]
     } else {


### PR DESCRIPTION
We are [working on an update](https://github.com/stan-dev/loo/pull/235) to the loo package that affects a few lines of code in your package.  This pull request should ensure compatibility with both the current version of loo and the next version. 

The change in loo will be that the threshold for flagging pareto k estimates will change from fixed at 0.7 to a [threshold determined by the posterior sample size](https://github.com/stan-dev/loo/issues/234). The resulting table of k estimates computed by `loo::pareto_k_table` will also now only have three rows for good, bad, and very bad.

If you want to test this PR with the version of loo that makes this change you can install that version using `remotes::install_github("stan-dev/loo", ref = "new-pareto-k-threshold")`. 