### PR TITLE
Suggest rstantools in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,7 +50,8 @@ Suggests:
     testthat,
     parallel,
     knitr,
-    rmarkdown
+    rmarkdown,
+    rstantools
 URL: https://fate-ewi.github.io/bayesdfa/
 BugReports: https://github.com/fate-ewi/bayesdfa/issues
 RoxygenNote: 7.3.2


### PR DESCRIPTION
Your configure script seems to call a function from `rstantools` but you have not declared it?
Therefore this fails: https://github.com/r-universe/cran/actions/runs/14430125146/job/40463931593